### PR TITLE
Add request latency log escalation

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -31,6 +31,10 @@ type (
 		NestKey string
 		// HandleError indicates whether to propagate errors up the middleware chain, so the global error handler can decide appropriate status code.
 		HandleError bool
+		// For long-running requests that take longer than this limit, log at a different level.  Ignored by default
+		RequestLatencyLimit time.Duration
+		// The level to log at if RequestLatencyLimit is exceeded
+		RequestLatencyLevel zerolog.Level
 	}
 
 	// Enricher is a function that can be used to enrich the logger with additional information.
@@ -126,10 +130,12 @@ func Middleware(config Config) echo.MiddlewareFunc {
 			}
 
 			stop := time.Now()
-
+			latency := stop.Sub(start)
 			var mainEvt *zerolog.Event
 			if err != nil {
 				mainEvt = logger.log.Err(err)
+			} else if config.RequestLatencyLimit != 0 && latency > config.RequestLatencyLimit {
+				mainEvt = logger.log.WithLevel(config.RequestLatencyLevel)
 			} else {
 				mainEvt = logger.log.WithLevel(logger.log.GetLevel())
 			}
@@ -148,8 +154,8 @@ func Middleware(config Config) echo.MiddlewareFunc {
 			evt.Str("user_agent", req.UserAgent())
 			evt.Int("status", res.Status)
 			evt.Str("referer", req.Referer())
-			evt.Dur("latency", stop.Sub(start))
-			evt.Str("latency_human", stop.Sub(start).String())
+			evt.Dur("latency", latency)
+			evt.Str("latency_human", latency.String())
 
 			cl := req.Header.Get(echo.HeaderContentLength)
 			if cl == "" {


### PR DESCRIPTION
This adds the ability to specify a duration and a log level within the config.  If a given request takes longer than the specified duration, it will be logged at this new level.

This use case is that we want requests to normally be logged at INFO, but using these new config options we could make long running requests be logged at warning.  This way we could go back and look at slow running requests.